### PR TITLE
docs: add Hanzilla Jobs student resource

### DIFF
--- a/README-2027.md
+++ b/README-2027.md
@@ -11,6 +11,7 @@ Includes **Winter, Summer, and Fall 2027** internships across **Montreal, Toront
 ### Looking for something else?
 
 - 📚 For the current 2026 cycle, check out [Canadian Tech Internships - 2026](README.md)
+- 🔎 For a broader daily-updated Canada-wide board with internships/co-ops, new-grad, junior, and entry-level roles across tech plus finance, engineering, business, and sciences, see [Hanzilla Jobs](https://jobs.hanzilla.co/internships/)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Covers **software development (backend, frontend, full-stack)**, **software engi
 ### Looking for something else?
 
 - 🚀 For **2027 Canadian tech internships** check out [Canadian Tech Internships - 2027](README-2027.md)
+- 🔎 For a broader daily-updated Canada-wide board with internships/co-ops, new-grad, junior, and entry-level roles across tech plus finance, engineering, business, and sciences, see [Hanzilla Jobs](https://jobs.hanzilla.co/internships/)
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds Hanzilla Jobs as an optional broader Canadian student job-board resource near the existing “Looking for something else?” section.
- Links to the internships landing page because this repository is internship-focused, while noting it also covers co-op, new-grad, junior and adjacent fields.

## Why
Hanzilla Jobs is a free daily-updated Canadian student/recent-grad board, so it can complement this curated tech-internship list for students who also want a broader Canada-wide search surface.

## Test plan
- `git diff --check`
