### PR TITLE
docs: add Hanzilla Jobs student resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Covers **software development (backend, frontend, full-stack)**, **software engi
 ### Looking for something else?
 
 - 🚀 For **2027 Canadian tech internships** check out [Canadian Tech Internships - 2027](README-2027.md)
+- 🇨🇦 For a broader daily-updated Canadian student/recent-grad board across tech plus finance, engineering, business, and science roles, try [Hanzilla Jobs](https://jobs.hanzilla.co/internships/)
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds Hanzilla Jobs as a broader Canada-focused student/recent-grad jobs resource under “Looking for something else?”
- Links directly to the internships page so students can find Canadian internship/co-op roles beyond this repo’s tech-only tracker

## Why
This repo is focused on verified Canadian tech internships. Hanzilla Jobs is a complementary daily-updated Canadian student/recent-grad board that also covers internships/co-ops across tech plus finance, engineering, business, sciences, and other early-career fields.

## Verification
- Link checked live: https://jobs.hanzilla.co/internships/
- One-line README-only change
