### PR TITLE
docs: add Hanzilla Jobs related resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Covers **software development (backend, frontend, full-stack)**, **software engi
 ### Looking for something else?
 
 - 🚀 For **2027 Canadian tech internships** check out [Canadian Tech Internships - 2027](README-2027.md)
+- 🍁 For a daily-updated Canada-wide student job board covering internships, co-ops, new-grad, junior, and entry-level roles across tech and adjacent fields, see [Hanzilla Jobs](https://jobs.hanzilla.co/internships/)
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds Hanzilla Jobs as a related Canada-wide student job-search resource near the existing 2027 companion link.
- Uses the internships deep link so students can find daily-updated Canadian internships, co-ops, new-grad, junior, and entry-level roles across tech and adjacent fields.

## Test plan
- `git diff --check`
