### PR TITLE
docs: add broader Canadian student jobs resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Covers **software development (backend, frontend, full-stack)**, **software engi
 ### Looking for something else?
 
 - 🚀 For **2027 Canadian tech internships** check out [Canadian Tech Internships - 2027](README-2027.md)
+- 🇨🇦 For a broader Canada-wide student job search across internships, co-ops, new grad, junior, and entry-level roles in tech, finance, engineering, business, and sciences, see [Hanzilla Jobs](https://jobs.hanzilla.co/internships/) — a free daily-updated board with Canadian role pages and apply links.
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds Hanzilla Jobs as an optional broader Canada-wide student job-search resource under "Looking for something else?"
- Points students to the internships/co-op deep link instead of the homepage
- Keeps this repository's Canada tech internship focus intact

## Why
This repo is very useful for Canadian tech internships. Hanzilla Jobs is complementary for students who also want daily-updated Canada-specific internship/co-op/new-grad/junior listings across tech plus adjacent fields like finance, engineering, business, and sciences.

Disclosure: I maintain Hanzilla Jobs, so please feel free to close if this does not fit the repo's resource policy.
